### PR TITLE
fix: 终端和页面切换时保持状态

### DIFF
--- a/src/components/terminal/terminal.css
+++ b/src/components/terminal/terminal.css
@@ -49,6 +49,25 @@
   margin-left: 4px;
 }
 
+/* 多终端容器包装器 */
+.term-container-wrapper {
+  flex-grow: 1;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+/* 每个终端容器独立定位 */
+.term-container-wrapper .term-connectelem {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 5px;
+  margin-left: 4px;
+}
+
 /* 关键：xterm 容器必须填满父元素 */
 .term-connectelem .xterm {
   height: 100%;


### PR DESCRIPTION
## 问题描述

用户在使用终端时遇到两个状态丢失问题：

1. **终端内标签页切换**：在终端内切换不同的标签页时，终端的内容和历史记录会被重置
2. **应用页面切换**：切换到其他功能页面（AI、网络、数据库等）再切回终端时，终端状态完全丢失

这严重影响了用户体验，导致用户无法保持多个终端会话的工作状态。

## 解决方案

### 1. 终端内标签页状态保持

**改为多容器架构**：
- 每个标签页拥有独立的终端容器（DOM 元素）和 TermWrap 实例
- 切换标签页时只改变容器的 `display` 属性（`block`/`none`）
- 不再销毁和重建 TermWrap，保持所有终端的状态和历史记录
- 只有在关闭标签页时才销毁对应的 TermWrap 实例

**技术细节**：
- `Tab` 接口添加 `termWrap` 字段保存实例引用
- 使用 `terminalContainerRef` 作为所有终端容器的父容器
- 每个终端容器使用 `data-tabId` 属性标识所属标签页
- 通过 CSS 绝对定位实现容器的叠加显示

### 2. 应用页面切换状态保持

**所有页面保持挂载**：
- 所有页面组件在首次访问后保持挂载在 DOM 中
- 使用 CSS `display` 属性控制页面的显示/隐藏
- 避免页面组件在切换时被卸载，保持所有页面的状态

**技术细节**：
- `PageWrapper` 和 `FullscreenWrapper` 添加 `$isActive` prop
- 将 `renderPage()` 改为 `renderAllPages()`
- 所有页面同时渲染，但只有当前页面可见
- Agent 和 Terminal 页面使用 inline style 控制显示（因为它们有特殊布局需求）

## 改动文件

### src/components/terminal/TerminalPage.tsx
- Tab 接口添加 `termWrap?: TermWrap` 字段
- 移除单一容器引用 `connectElemRef` 和 `termWrapRef`
- 添加 `terminalContainerRef` 作为多容器的父容器
- 为每个标签页创建独立的 DOM 容器
- 切换时只改变容器的 `display` 属性
- 关闭标签页时才销毁对应的 TermWrap

### src/components/terminal/terminal.css
- 添加 `.term-container-wrapper` 样式
- 每个 `.term-connectelem` 使用绝对定位
- 通过 `display` 属性控制显示/隐藏

### src/App.tsx
- `PageWrapper` 和 `FullscreenWrapper` 添加 `$isActive` prop
- 将 `renderPage()` 改为 `renderAllPages()`
- 所有页面同时渲染，但只有当前页面可见
- Agent 和 Terminal 页面使用 inline style 控制显示

## 测试

### 终端内标签页切换测试
1. 打开终端页面
2. 在第一个终端中输入命令（如 `ls`、`pwd`）
3. 创建第二个终端标签页
4. 在第二个终端中输入不同的命令
5. 切换回第一个标签页
6. ✅ 验证：第一个终端的内容和历史记录完整保留

### 应用页面切换测试
1. 打开终端页面并输入一些命令
2. 切换到其他功能页面（如 AI、网络、数据库）
3. 再切换回终端页面
4. ✅ 验证：终端内容和所有标签页状态完整保留

## 影响范围

- ✅ 不影响现有功能
- ✅ 向后兼容
- ✅ 通过所有 pre-commit 检查
- ✅ 改善用户体验，解决状态丢失问题

## 相关 Issue

解决用户反馈的终端状态丢失问题