### PR TITLE
fix: 终端和页面切换时保持状态

### DIFF
--- a/src/components/terminal/terminal.css
+++ b/src/components/terminal/terminal.css
@@ -49,6 +49,25 @@
   margin-left: 4px;
 }
 
+/* 多终端容器包装器 */
+.term-container-wrapper {
+  flex-grow: 1;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+/* 每个终端容器独立定位 */
+.term-container-wrapper .term-connectelem {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 5px;
+  margin-left: 4px;
+}
+
 /* 关键：xterm 容器必须填满父元素 */
 .term-connectelem .xterm {
   height: 100%;


### PR DESCRIPTION
问题:
1. 终端内标签页切换时状态会重置
2. 切换到其他功能页面再切回终端时状态丢失

解决方案:
1. 终端内标签页: 多容器架构，每个标签页独立容器和 TermWrap 实例
2. 应用页面切换: 所有页面保持挂载，使用 CSS display 控制显示

改动:
- TerminalPage.tsx: 多容器架构，保持 TermWrap 实例
- terminal.css: 添加多容器样式支持
- App.tsx: 所有页面保持挂载，CSS 控制显示