### PR TITLE
fix: 修复全局输入卡顿和终端 AI 模型列表问题

### DIFF
--- a/src/components/terminal/ai/TerminalAIInput.tsx
+++ b/src/components/terminal/ai/TerminalAIInput.tsx
@@ -6,9 +6,23 @@
  * 参考 Waveterm 的 AIPanelInput 设计
  */
 
-import React, { useRef, useCallback, useEffect } from "react";
+import React, { useRef, useCallback, useEffect, useMemo } from "react";
 import { Send, Square, Paperclip } from "lucide-react";
 import { cn } from "@/lib/utils";
+
+/**
+ * 简单的防抖函数
+ */
+function debounce<T extends (...args: unknown[]) => void>(
+  fn: T,
+  delay: number,
+): T {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  return ((...args: unknown[]) => {
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(...args), delay);
+  }) as T;
+}
 
 interface TerminalAIInputProps {
   /** 输入值 */
@@ -51,9 +65,17 @@ export const TerminalAIInput: React.FC<TerminalAIInputProps> = ({
     textarea.style.height = `${Math.min(scrollHeight, maxHeight)}px`;
   }, []);
 
+  /**
+   * 防抖的 resize 函数
+   */
+  const debouncedResize = useMemo(
+    () => debounce(resizeTextarea, 16), // ~60fps
+    [resizeTextarea],
+  );
+
   useEffect(() => {
-    resizeTextarea();
-  }, [value, resizeTextarea]);
+    debouncedResize();
+  }, [value, debouncedResize]);
 
   /**
    * 处理键盘事件

--- a/src/i18n/dom-replacer.ts
+++ b/src/i18n/dom-replacer.ts
@@ -54,6 +54,17 @@ export function replaceTextInDOM(language: Language): void {
         ) {
           return NodeFilter.FILTER_REJECT;
         }
+
+        // 跳过输入框和文本域（避免影响用户输入）
+        if (tagName === "INPUT" || tagName === "TEXTAREA") {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        // 跳过可编辑元素
+        if (parent.isContentEditable) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
         return NodeFilter.FILTER_ACCEPT;
       },
     },


### PR DESCRIPTION
- 优化 i18n MutationObserver 性能
  - 添加输入框变化过滤（INPUT、TEXTAREA）
  - 添加 300ms 防抖避免频繁触发
  - 跳过已打补丁的节点
  - 跳过可编辑元素

- 优化 DOM 文本替换性能
  - 跳过输入框和文本域
  - 跳过 contentEditable 元素

- 优化终端 AI 输入组件
  - 添加防抖函数（16ms ~60fps）
  - 使用 useMemo 缓存防抖函数

- 修复终端 AI 模型列表问题
  - 添加 extractSupportedModels 函数
  - 优先使用凭证池中的模型列表
  - 特殊处理 DeepSeek（显示 deepseek-chat/reasoner）
  - 修复 iFlow provider ID 映射（openai -> iflowcn）
  - 降级到 model registry（如果凭证模型为空）

修复后：
- 所有输入框流畅无卡顿
- 终端 AI 显示正确的提供商模型列表