### PR TITLE
fix: 修复 Flow Monitor 响应内容显示和提供商显示问题 (#75)

### DIFF
--- a/src-tauri/src/commands/flow_monitor_cmd.rs
+++ b/src-tauri/src/commands/flow_monitor_cmd.rs
@@ -791,6 +791,7 @@ pub async fn create_test_flows(
         // 创建测试元数据
         let metadata = FlowMetadata {
             provider: ProviderType::OpenAI,
+            provider_id: Some("openai".to_string()),
             credential_id: Some(format!("test-cred-{}", i)),
             credential_name: Some(format!("测试凭证 {}", i)),
             retry_count: 0,

--- a/src-tauri/src/flow_monitor/diff.rs
+++ b/src-tauri/src/flow_monitor/diff.rs
@@ -1269,6 +1269,7 @@ mod property_tests {
     fn arb_flow_metadata() -> impl Strategy<Value = FlowMetadata> {
         arb_provider_type().prop_map(|provider| FlowMetadata {
             provider,
+            provider_id: None,
             credential_id: None,
             credential_name: None,
             retry_count: 0,

--- a/src-tauri/src/flow_monitor/exporter.rs
+++ b/src-tauri/src/flow_monitor/exporter.rs
@@ -1618,6 +1618,7 @@ mod property_tests {
     fn arb_flow_metadata() -> impl Strategy<Value = FlowMetadata> {
         arb_provider_type().prop_map(|provider| FlowMetadata {
             provider,
+            provider_id: None,
             credential_id: None,
             credential_name: None,
             retry_count: 0,
@@ -1969,6 +1970,7 @@ mod redaction_property_tests {
 
                     let metadata = FlowMetadata {
                         provider,
+                        provider_id: None,
                         credential_id: None,
                         credential_name: None,
                         retry_count: 0,

--- a/src-tauri/src/flow_monitor/memory_store.rs
+++ b/src-tauri/src/flow_monitor/memory_store.rs
@@ -394,19 +394,28 @@ impl FlowMemoryStore {
     pub fn add(&mut self, flow: LLMFlow) {
         let id = flow.id.clone();
 
+        eprintln!(
+            "[MEMORY_STORE] 添加 Flow: id={}, model={}, state={:?}",
+            id, flow.request.model, flow.state
+        );
+
         // 如果已存在，先移除旧的
         if self.flows.contains_key(&id) {
             self.ordered_ids.retain(|i| i != &id);
+            eprintln!("[MEMORY_STORE] 移除旧的 Flow: id={}", id);
         }
 
         // 检查是否需要驱逐
         while self.flows.len() >= self.max_size {
+            eprintln!("[MEMORY_STORE] 缓存已满，驱逐最旧的 Flow");
             self.evict_oldest();
         }
 
         // 添加新 Flow
         self.flows.insert(id.clone(), Arc::new(RwLock::new(flow)));
-        self.ordered_ids.push_back(id);
+        self.ordered_ids.push_back(id.clone());
+
+        eprintln!("[MEMORY_STORE] Flow 已添加，当前数量: {}", self.flows.len());
     }
 
     /// 获取 Flow

--- a/src-tauri/src/flow_monitor/models.rs
+++ b/src-tauri/src/flow_monitor/models.rs
@@ -539,6 +539,9 @@ pub struct ToolCallDelta {
 pub struct FlowMetadata {
     /// 提供商类型
     pub provider: ProviderType,
+    /// 提供商 ID（实际的 provider ID，如 "deepseek", "moonshot" 等）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_id: Option<String>,
     /// 凭证 ID
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credential_id: Option<String>,
@@ -564,6 +567,7 @@ impl Default for FlowMetadata {
     fn default() -> Self {
         Self {
             provider: ProviderType::Kiro,
+            provider_id: None,
             credential_id: None,
             credential_name: None,
             retry_count: 0,
@@ -1063,6 +1067,7 @@ mod property_tests {
         )
             .prop_map(|(provider, credential_id, credential_name)| FlowMetadata {
                 provider,
+                provider_id: None,
                 credential_id,
                 credential_name,
                 retry_count: 0,

--- a/src-tauri/tests/end_to_end_tests.rs
+++ b/src-tauri/tests/end_to_end_tests.rs
@@ -128,6 +128,7 @@ impl E2ETestContext {
             error: None,
             metadata: FlowMetadata {
                 provider: provider,
+                provider_id: None,
                 credential_name: Some("test-cred".to_string()),
                 credential_id: Some("test-cred-id".to_string()),
                 retry_count: 0,

--- a/src/components/flow-monitor/FlowDetail.tsx
+++ b/src/components/flow-monitor/FlowDetail.tsx
@@ -383,7 +383,10 @@ function FlowDetailHeader({
       <div className="rounded-lg border bg-card p-4">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <InfoItem label="模型" value={flow.request.model} />
-          <InfoItem label="提供商" value={flow.metadata.provider} />
+          <InfoItem
+            label="提供商"
+            value={flow.metadata.provider_id || flow.metadata.provider}
+          />
           <InfoItem label="类型" value={formatFlowType(flow.flow_type)} />
           <InfoItem
             label="创建时间"
@@ -784,6 +787,18 @@ function ResponseTab({
   onCopy,
 }: ResponseTabProps) {
   const { response } = flow;
+
+  // 调试日志
+  console.log("[FlowDetail] ResponseTab - response:", response);
+  console.log("[FlowDetail] ResponseTab - content:", response?.content);
+  console.log(
+    "[FlowDetail] ResponseTab - content length:",
+    response?.content?.length,
+  );
+  console.log(
+    "[FlowDetail] ResponseTab - expandedSections:",
+    Array.from(expandedSections),
+  );
 
   if (!response) {
     return (

--- a/src/components/flow-monitor/FlowList.tsx
+++ b/src/components/flow-monitor/FlowList.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import * as Select from "@radix-ui/react-select";
 import {
   CheckCircle2,
   XCircle,
@@ -21,6 +22,7 @@ import {
   Activity,
   Bell,
   BellOff,
+  Check,
 } from "lucide-react";
 import {
   flowMonitorApi,
@@ -570,16 +572,59 @@ export function FlowList({
               )}
             </button>
           )}
-          <select
-            className="rounded border bg-background px-2 py-1 text-sm"
+          <Select.Root
             value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as FlowSortBy)}
+            onValueChange={(value) => setSortBy(value as FlowSortBy)}
           >
-            <option value="created_at">按时间</option>
-            <option value="duration">按耗时</option>
-            <option value="total_tokens">按 Token</option>
-            <option value="model">按模型</option>
-          </select>
+            <Select.Trigger className="inline-flex min-w-[120px] items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring">
+              <Select.Value />
+              <Select.Icon>
+                <ChevronDown className="h-4 w-4 opacity-50" />
+              </Select.Icon>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Content className="relative z-50 min-w-[120px] overflow-hidden rounded-md border border-border bg-white dark:bg-gray-900 text-foreground shadow-lg animate-in fade-in-80 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2">
+                <Select.Viewport className="p-1 bg-white dark:bg-gray-900">
+                  <Select.Item
+                    value="created_at"
+                    className="relative flex cursor-pointer select-none items-center rounded-sm px-8 py-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                  >
+                    <Select.ItemIndicator className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                      <Check className="h-4 w-4" />
+                    </Select.ItemIndicator>
+                    <Select.ItemText>按时间</Select.ItemText>
+                  </Select.Item>
+                  <Select.Item
+                    value="duration"
+                    className="relative flex cursor-pointer select-none items-center rounded-sm px-8 py-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                  >
+                    <Select.ItemIndicator className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                      <Check className="h-4 w-4" />
+                    </Select.ItemIndicator>
+                    <Select.ItemText>按耗时</Select.ItemText>
+                  </Select.Item>
+                  <Select.Item
+                    value="total_tokens"
+                    className="relative flex cursor-pointer select-none items-center rounded-sm px-8 py-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                  >
+                    <Select.ItemIndicator className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                      <Check className="h-4 w-4" />
+                    </Select.ItemIndicator>
+                    <Select.ItemText>按 Token</Select.ItemText>
+                  </Select.Item>
+                  <Select.Item
+                    value="model"
+                    className="relative flex cursor-pointer select-none items-center rounded-sm px-8 py-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                  >
+                    <Select.ItemIndicator className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                      <Check className="h-4 w-4" />
+                    </Select.ItemIndicator>
+                    <Select.ItemText>按模型</Select.ItemText>
+                  </Select.Item>
+                </Select.Viewport>
+              </Select.Content>
+            </Select.Portal>
+          </Select.Root>
           <button
             onClick={() => setSortDesc(!sortDesc)}
             className="rounded border px-2 py-1 text-sm hover:bg-muted"

--- a/src/lib/api/flowMonitor.ts
+++ b/src/lib/api/flowMonitor.ts
@@ -333,6 +333,7 @@ export interface RoutingInfo {
  */
 export interface FlowMetadata {
   provider: ProviderType;
+  provider_id?: string; // 实际的 provider ID（如 "deepseek", "moonshot" 等）
   credential_id?: string;
   credential_name?: string;
   retry_count: number;


### PR DESCRIPTION
# 修复 Flow Monitor 响应内容显示和提供商显示问题

## 问题描述

修复 Issue #75：Flow Monitor 界面无法正确显示响应内容和提供商信息

### 主要问题

1. **响应内容未显示**：在凭证池模式下，非流式响应的 `content` 和 `body` 字段没有被正确保存到 Flow Monitor
2. **提供商显示错误**：Flow Monitor 显示提供商为 "openai" 而不是实际的提供商名称（如 "DeepSeek"）

## 修复内容

### 1. 修复响应内容保存问题

**文件**: `src-tauri/src/server/handlers/api.rs`

- 在凭证池模式下正确提取响应体内容（第 1040-1210 行）
- 解析 JSON 响应，提取 `content`、`tool_calls` 和 `usage` 信息
- 优先从 `content` 字段提取，如果为空则从 `tool_calls` 提取
- 提取并设置响应头到 `LLMResponse.headers`
- 使用实际的 token 使用量而不是默认值

**根本原因**:
- `build_llm_response` 被调用时传入空字符串
- `body` 字段被硬编码为 `serde_json::Value::Null`
- 当响应包含 `tool_calls` 时，`content` 字段为空，实际内容在 `tool_calls[0].function.arguments` 中

### 2. 修复提供商显示问题

**文件**: 
- `src-tauri/src/flow_monitor/models.rs`
- `src-tauri/src/server/handlers/api.rs`
- `src/lib/api/flowMonitor.ts`
- `src/components/flow-monitor/FlowDetail.tsx`

**修改内容**:
- 在 `FlowMetadata` 结构体中添加 `provider_id: Option<String>` 字段
- 修改 `build_flow_metadata` 函数签名，添加 `provider_id` 参数
- 更新所有调用 `build_flow_metadata` 的地方，传入实际的 provider ID
- 修改前端显示逻辑，优先显示 `provider_id`
- 从凭证的 `name` 字段中提取 Provider 显示名称（去掉 "[降级] " 前缀）

**根本原因**:
- `FlowMetadata.provider` 是 `ProviderType` 枚举，不包含具体的提供商 ID
- "deepseek" 等提供商被解析为 `ProviderType::OpenAI`

### 3. UI 优化

**清理完成弹窗** (`src/components/flow-monitor/CleanupDialog.tsx`):
- 创建自定义成功提示 Modal 组件
- 添加动画成功图标（带圆环动画效果）
- 使用渐变背景和图标卡片展示统计信息
- 区分不同类型信息（蓝色：删除记录，紫色：清理文件，绿色：释放空间）
- 支持深色模式

**排序下拉框** (`src/components/flow-monitor/FlowList.tsx`):
- 将原生 `<select>` 替换为 Radix UI 的 `Select` 组件
- 使用与"监听地址"下拉框相同的样式
- 添加选中状态指示器（✓）
- 支持键盘导航和无障碍访问

### 4. 调试日志增强

**文件**: 
- `src-tauri/src/flow_monitor/monitor.rs`
- `src-tauri/src/flow_monitor/memory_store.rs`
- `src-tauri/src/flow_monitor/query_service.rs`
- `src-tauri/src/server/handlers/api.rs`

添加详细的调试日志用于追踪 Flow 显示问题：
- 记录 Flow 创建、活跃 Flow 数量
- 记录 Flow 完成、保存到内存/文件的状态
- 记录查询过程、内存/文件查询结果、合并后的总数

### 5. 测试修复

修复所有测试代码中缺少 `provider_id` 字段的问题：
- `src-tauri/src/flow_monitor/diff.rs`
- `src-tauri/src/flow_monitor/exporter.rs`
- `src-tauri/src/flow_monitor/models.rs`
- `src-tauri/tests/end_to_end_tests.rs`
- `src-tauri/src/commands/flow_monitor_cmd.rs`

## 测试结果

- ✅ 响应内容正确显示
- ✅ 提供商名称正确显示（如 "DeepSeek"）
- ✅ 清理完成弹窗样式优化
- ✅ 排序下拉框样式优化
- ✅ 所有测试通过
- ✅ 代码格式检查通过

## 注意事项

**数据兼容性**: 由于添加了新的 `provider_id` 字段，旧的 Flow 数据可能需要清理才能正常显示。建议用户在更新后执行一次 Flow 清理操作。

## 相关 Issue

Closes #75
