### PR TITLE
fix: 消除跨平台编译警告

### DIFF
--- a/src-tauri/src/app/runner.rs
+++ b/src-tauri/src/app/runner.rs
@@ -5,6 +5,9 @@
 use std::sync::Arc;
 use tauri::Manager;
 
+#[cfg(target_os = "macos")]
+use tauri::{Emitter, Listener};
+
 use crate::commands;
 use crate::tray::{TrayIconStatus, TrayManager, TrayStateSnapshot};
 

--- a/src-tauri/src/commands/provider_pool_cmd.rs
+++ b/src-tauri/src/commands/provider_pool_cmd.rs
@@ -2934,7 +2934,11 @@ pub struct PlaywrightStatus {
 
 /// 获取系统 Chrome 可执行文件路径
 fn get_system_chrome_path() -> Option<String> {
-    let _home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    #[cfg_attr(
+        not(any(target_os = "macos", target_os = "windows")),
+        allow(unused_variables)
+    )]
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
 
     #[cfg(target_os = "macos")]
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //! 这是一个 Tauri 应用，提供 AI API 的代理和管理功能。
 
+// 抑制 objc crate 宏内部的 unexpected_cfgs 警告
+// 该警告来自 cocoa/objc 依赖的 msg_send! 宏，是已知的 issue
+#![allow(unexpected_cfgs)]
+
 // 核心模块
 pub mod agent;
 pub mod app;

--- a/src-tauri/src/screenshot/capture.rs
+++ b/src-tauri/src/screenshot/capture.rs
@@ -6,6 +6,9 @@ use std::path::PathBuf;
 use tauri::AppHandle;
 use tracing::{debug, error, info};
 
+#[cfg(target_os = "macos")]
+use tracing::warn;
+
 /// 截图错误类型
 #[derive(Debug, thiserror::Error)]
 pub enum CaptureError {

--- a/src-tauri/src/screenshot/window.rs
+++ b/src-tauri/src/screenshot/window.rs
@@ -8,8 +8,10 @@ use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 use tracing::{debug, info};
 
 #[cfg(target_os = "macos")]
+#[allow(deprecated)]
 use cocoa::appkit::{NSColor, NSWindow};
 #[cfg(target_os = "macos")]
+#[allow(deprecated)]
 use cocoa::base::{id, nil};
 
 /// 窗口错误类型
@@ -164,6 +166,7 @@ pub fn open_floating_window(app: &AppHandle, image_path: &Path) -> Result<(), Wi
         {
             use objc::{msg_send, sel, sel_impl};
             if let Ok(ns_win) = window.ns_window() {
+                #[allow(deprecated, unexpected_cfgs)]
                 unsafe {
                     let ns_window = ns_win as id;
                     // 设置窗口背景透明
@@ -202,24 +205,25 @@ pub fn open_floating_window(app: &AppHandle, image_path: &Path) -> Result<(), Wi
     let (x, y) = calculate_window_position(app);
 
     // 创建悬浮窗口（启用透明）
-    let _window =
-        WebviewWindowBuilder::new(app, FLOATING_WINDOW_LABEL, WebviewUrl::App(url.into()))
-            .inner_size(WINDOW_WIDTH, WINDOW_HEIGHT)
-            .position(x, y)
-            .decorations(false)
-            .always_on_top(true)
-            .skip_taskbar(true)
-            .visible(true)
-            .focused(true)
-            .transparent(true)
-            .build()
-            .map_err(|e| WindowError::CreateFailed(format!("{}", e)))?;
+    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+    let window = WebviewWindowBuilder::new(app, FLOATING_WINDOW_LABEL, WebviewUrl::App(url.into()))
+        .inner_size(WINDOW_WIDTH, WINDOW_HEIGHT)
+        .position(x, y)
+        .decorations(false)
+        .always_on_top(true)
+        .skip_taskbar(true)
+        .visible(true)
+        .focused(true)
+        .transparent(true)
+        .build()
+        .map_err(|e| WindowError::CreateFailed(format!("{}", e)))?;
 
     // macOS: 设置窗口和 webview 背景透明
     #[cfg(target_os = "macos")]
     {
         use objc::{msg_send, sel, sel_impl};
         if let Ok(ns_win) = window.ns_window() {
+            #[allow(deprecated, unexpected_cfgs)]
             unsafe {
                 let ns_window = ns_win as id;
                 // 设置窗口背景透明

--- a/src-tauri/src/services/update_window.rs
+++ b/src-tauri/src/services/update_window.rs
@@ -12,8 +12,10 @@ use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 use tracing::{debug, info};
 
 #[cfg(target_os = "macos")]
+#[allow(deprecated)]
 use cocoa::appkit::{NSColor, NSWindow};
 #[cfg(target_os = "macos")]
+#[allow(deprecated)]
 use cocoa::base::{id, nil};
 
 use super::update_check_service::UpdateInfo;
@@ -164,7 +166,8 @@ pub fn open_update_window(
 
     let (x, y) = calculate_window_position(app);
 
-    let _window = WebviewWindowBuilder::new(app, UPDATE_WINDOW_LABEL, WebviewUrl::App(url.into()))
+    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+    let window = WebviewWindowBuilder::new(app, UPDATE_WINDOW_LABEL, WebviewUrl::App(url.into()))
         .inner_size(WINDOW_WIDTH, WINDOW_HEIGHT)
         .position(x, y)
         .decorations(false)
@@ -182,6 +185,7 @@ pub fn open_update_window(
     {
         use objc::{msg_send, sel, sel_impl};
         if let Ok(ns_win) = window.ns_window() {
+            #[allow(deprecated, unexpected_cfgs)]
             unsafe {
                 let ns_window = ns_win as id;
                 let clear_color = NSColor::clearColor(nil);


### PR DESCRIPTION
## 📋 变更摘要

修复 macOS 和 Linux 平台上的 Rust 编译警告，实现零警告编译。

## 🔧 主要更改

### 1. 全局 Lint 配置
- **src/lib.rs**: 添加 `#![allow(unexpected_cfgs)]` 抑制 objc crate 宏内部的 cfg 警告

### 2. 平台特定导入
- **src/app/runner.rs**: macOS 特定的 `Emitter`/`Listener` trait 条件导入
- **src/screenshot/capture.rs**: macOS 特定的 `warn!` 宏条件导入

### 3. 变量命名修复
- **src/screenshot/window.rs**: 修复 `_window` 变量命名（移除下划线前缀）
- **src/services/update_window.rs**: 修复 `_window` 变量命名
- **src/commands/provider_pool_cmd.rs**: 修复 `_home` 变量命名

### 4. Lint 属性优化
- 使用 `#[cfg(target_os = "macos")]` 条件导入
- 使用 `#[cfg_attr]` 条件属性抑制非目标平台的未使用变量警告
- 在 cocoa 导入处添加 `#[allow(deprecated)]`

## ✅ 验证结果

- **macOS**: `cargo check --no-default-features` 零警告 ✅
- **Linux**: `cargo check --no-default-features` 零警告 ✅
- **Pre-commit hooks**: 全部通过 ✅

## 📝 技术细节

### 问题根源
1. **跨 crate 边界警告**: `msg_send!` 宏来自 `objc` crate，其内部的 `cfg(clippy)` 警告跨越 crate 边界
2. **模块属性语法**: 子模块文件中的 `#![allow]` 语法不生效，必须在 crate 根（lib.rs）使用
3. **条件编译差异**: macOS 特定代码在 Linux 上被跳过，导致未使用变量警告

### 解决方案
- 在 `lib.rs` (crate 根) 添加全局 `#![allow(unexpected_cfgs)]`
- 使用 `#[cfg(target_os = "...")]` 条件导入平台特定模块
- 使用 `#[cfg_attr]` 条件属性抑制非目标平台的警告

## 🔗 相关 Issue

无

---

**提交记录**: 76d623f
**分支**: dev/260111-1931 → main