### PR TITLE
fix: 修复凭证代理设置无法清空的问题

### DIFF
--- a/src/components/provider-pool/EditCredentialModal.tsx
+++ b/src/components/provider-pool/EditCredentialModal.tsx
@@ -220,8 +220,8 @@ export function EditCredentialModal({
         new_base_url: isApiKey ? newBaseUrl.trim() : undefined,
         // API Key 的 api_key（始终传递当前值）
         new_api_key: isApiKey ? newApiKey.trim() : undefined,
-        // 代理 URL（空字符串表示清除，使用全局代理）
-        new_proxy_url: proxyUrl.trim() || undefined,
+        // 代理 URL：始终传递当前值，空字符串表示清除代理
+        new_proxy_url: proxyUrl.trim(),
       };
 
       console.log("[EditCredentialModal] 提交更新请求:", updateRequest);


### PR DESCRIPTION
## 问题描述
修复 Issue #107：凭证代理设置无法清空/移除

## 问题原因
`EditCredentialModal.tsx` 中 `proxyUrl.trim() || undefined` 在空字符串时返回 `undefined`，导致后端不会更新代理设置。

## 修复方案
将 `proxyUrl.trim() || undefined` 改为 `proxyUrl.trim()`，这样空字符串会被正确传递给后端，后端会将其解释为清除代理设置。

## 修改文件
- `src/components/provider-pool/EditCredentialModal.tsx`

Closes #107