### PR TITLE
fix(server): 修复监听地址配置不生效的问题 (#110)

### DIFF
--- a/src-tauri/src/app/bootstrap.rs
+++ b/src-tauri/src/app/bootstrap.rs
@@ -87,19 +87,12 @@ pub fn load_and_validate_config() -> Result<Config, ConfigError> {
         return Err(ConfigError::InvalidHost);
     }
 
-    let is_non_local = is_non_local_bind(&config.server.host);
-
-    // 如果是本地绑定且使用默认 API key，自动生成新密钥
-    if !is_non_local && config.server.api_key == config::DEFAULT_API_KEY {
+    // 如果使用默认 API key，自动生成新密钥
+    if config.server.api_key == config::DEFAULT_API_KEY {
         let new_key = generate_api_key();
         config.server.api_key = new_key;
         config::save_config(&config).map_err(|e| ConfigError::SaveFailed(e.to_string()))?;
         tracing::info!("检测到默认 API key，已自动生成并保存新密钥");
-    }
-
-    // 如果是非本地绑定，必须使用非默认 API key
-    if is_non_local && config.server.api_key == config::DEFAULT_API_KEY {
-        return Err(ConfigError::DefaultApiKeyWithNonLocalBind);
     }
 
     // 检查 TLS 配置

--- a/src-tauri/src/app/utils.rs
+++ b/src-tauri/src/app/utils.rs
@@ -98,17 +98,28 @@ mod tests {
         // 监听所有接口
         assert!(is_valid_bind_host("0.0.0.0"));
         assert!(is_valid_bind_host("::"));
-        // 其他地址不允许
-        assert!(!is_valid_bind_host("192.168.1.1"));
-        assert!(!is_valid_bind_host("10.0.0.1"));
+        // 私有网络地址（局域网）- 应该允许
+        assert!(is_valid_bind_host("192.168.1.1"));
+        assert!(is_valid_bind_host("10.0.0.1"));
+        assert!(is_valid_bind_host("172.16.0.1"));
+        assert!(is_valid_bind_host("172.31.255.255"));
+        // 公网地址不允许
+        assert!(!is_valid_bind_host("8.8.8.8"));
+        assert!(!is_valid_bind_host("1.1.1.1"));
     }
 
     #[test]
     fn test_is_non_local_bind() {
+        // 监听所有接口
         assert!(is_non_local_bind("0.0.0.0"));
         assert!(is_non_local_bind("::"));
+        // 回环地址不是非本地绑定
         assert!(!is_non_local_bind("127.0.0.1"));
         assert!(!is_non_local_bind("localhost"));
+        // 私有网络地址是非本地绑定（需要强 API Key）
+        assert!(is_non_local_bind("192.168.1.1"));
+        assert!(is_non_local_bind("10.0.0.1"));
+        assert!(is_non_local_bind("172.16.0.1"));
     }
 
     #[test]

--- a/src-tauri/src/config/hot_reload.rs
+++ b/src-tauri/src/config/hot_reload.rs
@@ -418,15 +418,6 @@ impl HotReloadManager {
             ));
         }
 
-        // 非本地绑定或远程管理时，禁止使用默认 API Key
-        if (is_non_local || !is_localhost || config.remote_management.allow_remote)
-            && is_default_api_key(&config.server.api_key)
-        {
-            return Err(HotReloadError::ValidationError(
-                "监听所有网络接口或开启远程管理时，禁止使用默认 API Key，请设置强口令".to_string(),
-            ));
-        }
-
         if config.server.tls.enable {
             return Err(HotReloadError::ValidationError(
                 "当前版本暂不支持 TLS，请关闭 TLS 配置".to_string(),

--- a/src-tauri/src/dev_bridge.rs
+++ b/src-tauri/src/dev_bridge.rs
@@ -91,7 +91,13 @@ impl DevBridgeServer {
             .with_state(app_state);
 
         let addr = format!("{}:{}", config.host, config.port);
-        let listener = tokio::net::TcpListener::bind(&addr).await?;
+        let listener = match tokio::net::TcpListener::bind(&addr).await {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("[DevBridge] 绑定失败: {} (地址: {})", e, addr);
+                return Err(e.into());
+            }
+        };
 
         eprintln!("[DevBridge] 正在监听: http://{}", addr);
 


### PR DESCRIPTION
## 问题描述
用户在 UI 中选择 127.0.0.1 或 0.0.0.0 作为监听地址，但服务器实际绑定到局域网 IP

## 修复内容
1. 移除 server/mod.rs 中的自动地址替换逻辑
2. 移除监听 0.0.0.0 时必须使用非默认 API Key 的限制
3. 修复 VPN 地址被错误显示在路由端点的问题
4. 前端选择监听地址后自动保存配置
5. 移除前端的安全提示信息