### PR TITLE
fix(ui): 修复自定义模型无法在模型选择器中显示的问题

### DIFF
--- a/src/hooks/useConfiguredProviders.ts
+++ b/src/hooks/useConfiguredProviders.ts
@@ -34,6 +34,8 @@ export interface ConfiguredProvider {
   credentialType?: string;
   /** Provider ID（用于 API Key Provider） */
   providerId?: string;
+  /** 自定义模型列表（用于 API Key Provider） */
+  customModels?: string[];
 }
 
 export interface UseConfiguredProvidersResult {
@@ -127,6 +129,7 @@ export function useConfiguredProviders(): UseConfiguredProvidersResult {
             type: provider.type,
             credentialType: `${provider.type}_key`,
             providerId: provider.id,
+            customModels: provider.custom_models,
           });
         }
       });


### PR DESCRIPTION
## 问题描述

修复自定义模型无法在模型选择器中显示的问题 (#118)

## 修改内容

### ApiServerPage.tsx
- 修改 `loadModels` 函数，使用 `provider.id` 作为 `registryId`（适用于系统预设的 Provider，如 deepseek, moonshot）
- 优先显示自定义模型（排在最前面），然后显示模型注册表中的模型
- 如果 `registryId` 没有模型，回退到使用 `type` 映射的 `fallbackRegistryId`
- 删除不再使用的 `getModelProviderIds` 函数

### useProviderModels.ts / useConfiguredProviders.ts
- 添加 `customModels` 字段支持
- 优化模型列表合并逻辑，避免重复

## 修复效果

- DeepSeek 等自定义 Provider 现在只显示其专属模型，不再显示不相关的 OpenAI 模型
- 自定义模型（`custom_models` 字段）正确显示在模型选择器的最前面
- 模型注册表中的模型作为补充显示在自定义模型之后

## 测试

- [x] 前端构建通过
- [x] ESLint 检查通过
- [x] DeepSeek Provider 只显示 DeepSeek 模型
- [x] 自定义模型正确显示在列表最前面

Closes #118
